### PR TITLE
Typo (incomplete refactor) on a config restructure

### DIFF
--- a/src/groovy/grails/plugins/sass/CompassInvoker.groovy
+++ b/src/groovy/grails/plugins/sass/CompassInvoker.groovy
@@ -44,7 +44,7 @@ class CompassInvoker {
         def sass_dir = config.grass?.sass_dir
         def css_dir = config.grass?.css_dir
         def images_dir = config.grass?.images_dir
-        def relative_assets = config.grass?.relative_assets == null ? true : config.compass?.relative_assets
+        def relative_assets = config.grass?.relative_assets == null ? true : config.grass?.relative_assets
         def output_style = config.grass?.output_style ?: 'compact'
 
         ensureParameterSet sass_dir, "sass_dir is not set (GrassConfig.groovy)", callback


### PR DESCRIPTION
I think this fixes a small typo bug that I posted here:

https://github.com/stefankendall/compass-sass/issues/2
