### PR TITLE
Adding line_comments compass feature to the plugin

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -41,6 +41,8 @@ You can also use the <a href='http://grails.org/plugin/resources'>resources plug
 * **css_dir**: Output directory for compiled CSS.
 * **relative_assets**: Whether or not compass will generate relative URLs.  
 `Values: true, false`
+* **line_comments**: Whether or not compass will generate debugging comments that display the original location of your selectors. URLs.
+`Values: true, false`
 * **output_style**: The output format of the CSS.   
 `Values: nested, expanded, compact, compressed`
 * **framework\_output\_type**: The output of install-blueprint.   

--- a/grails-app/conf/DefaultGrassConfig.groovy
+++ b/grails-app/conf/DefaultGrassConfig.groovy
@@ -8,6 +8,9 @@ grass {
     // default is true
     relative_assets = true
 
+    // default is true
+    line_comments = true
+
     // other options: nested, expanded, compact, compressed
     output_style = "compact"
 

--- a/src/groovy/grails/plugins/sass/CompassInvoker.groovy
+++ b/src/groovy/grails/plugins/sass/CompassInvoker.groovy
@@ -45,6 +45,7 @@ class CompassInvoker {
         def css_dir = config.grass?.css_dir
         def images_dir = config.grass?.images_dir
         def relative_assets = config.grass?.relative_assets == null ? true : config.compass?.relative_assets
+        def line_comments = config.grass?.line_comments == null ? true : config.grass?.line_comments
         def output_style = config.grass?.output_style ?: 'compact'
 
         ensureParameterSet sass_dir, "sass_dir is not set (GrassConfig.groovy)", callback
@@ -58,6 +59,7 @@ class CompassInvoker {
                 '--css-dir', "${css_dir}",
                 images_dir ? ['--images-dir', "${images_dir}"] : [],
                 relative_assets ? "--relative-assets" : "",
+                line_comments ? "" : "--no-line-comments",
                 '--output-style', "${output_style}"].flatten()
 
         def p = runCompassCommand(sassCompileCommandLineArgs)

--- a/test/unit/grails/plugins/sass/CompassInvokerTest.groovy
+++ b/test/unit/grails/plugins/sass/CompassInvokerTest.groovy
@@ -18,6 +18,7 @@ class CompassInvokerTest extends GroovyTestCase {
                     css_dir: 'src/web-app/css',
                     images_dir: 'src/web-app/images',
                     relative_assets: true,
+                    line_comments: true,
                     framework_output_type: 'sass'
             ]
     ]


### PR DESCRIPTION
This should add the ability to turn off original source file location debug lines
