### PR TITLE
Making GrassConfig.groovy environment aware

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -56,6 +56,27 @@ You can also use the <a href='http://grails.org/plugin/resources'>resources plug
 `Values: sass, scss`
 * **images_dir**: *(Optional)* Location for images referenced in CSS.
 
+GrassConfig.groovy is an environment-aware config file, so you can customize the behavior by adding an environments block. The following would keep CSS files compressed except in your development environment:
+
+<pre><code>grass {
+    sass_dir = "./src/stylesheets"
+    css_dir = "./web-app/css"
+    images_dir = "./web-app/images"
+    relative_assets = true
+    framework_output_type = "scss"
+    line_comments = false
+    output_style = "compressed"
+}
+environments {
+    development {
+        grass {
+            line_comments = true
+            output_style = "compact"
+        }
+    }
+}</code></pre>
+
+
 ##What if my team members/I don't have jRuby installed?##
 If jRuby is not installed, you will receive a warning during run-app, and SASS/SCSS files will not be compiled. As long as you check in compiled CSS, this isn't an issue for multiple-developer teams. If you want to use the resources plugin, everyone will need jRuby installed.
 

--- a/grails-app/resourceMappers/SassResourceMapper.groovy
+++ b/grails-app/resourceMappers/SassResourceMapper.groovy
@@ -1,7 +1,8 @@
-import grails.util.GrailsUtil
 import org.grails.plugin.resource.mapper.MapperPhase
 import grails.plugins.sass.JavaProcessKiller
 import grails.plugins.sass.CompassInvoker
+import grails.util.GrailsUtil
+//import grails.util.Environment
 
 class SassResourceMapper {
     def grailsApplication
@@ -38,8 +39,10 @@ class SassResourceMapper {
     private ConfigObject getConfig() {
         def config = new ConfigObject()
         def classLoader = new GroovyClassLoader(getClass().classLoader)
+        //config.merge(new ConfigSlurper(Environment.getCurrent().getName()).parse(classLoader.loadClass('DefaultGrassConfig')))
         config.merge(new ConfigSlurper(GrailsUtil.environment).parse(classLoader.loadClass('DefaultGrassConfig')))
         try {
+            //new ConfigSlurper(Environment.getCurrent().getName()).parse(classLoader.loadClass('GrassConfig'))
             new ConfigSlurper(GrailsUtil.environment).parse(classLoader.loadClass('GrassConfig'))
         }
         catch (Exception ignored) {

--- a/src/groovy/grails/plugins/sass/CompassInvoker.groovy
+++ b/src/groovy/grails/plugins/sass/CompassInvoker.groovy
@@ -1,12 +1,16 @@
 package grails.plugins.sass
 
+import grails.util.GrailsUtil
+//import grails.util.Environment
+
 class CompassInvoker {
     def config
     def javaProcessKiller
     boolean forceRecompile = false
 
     public CompassInvoker(File grassConfigLocation, def javaProcessKiller) {
-        this(new ConfigSlurper().parse(grassConfigLocation.toURL()), javaProcessKiller)
+        //this(new ConfigSlurper(Environment.getCurrent().getName()).parse(grassConfigLocation.toURL()), javaProcessKiller)
+        this(new ConfigSlurper(GrailsUtil.environment).parse(grassConfigLocation.toURL()), javaProcessKiller)
     }
 
     public CompassInvoker(def config, def javaProcessKiller) {


### PR DESCRIPTION
Well, my project is getting close to release, and we realize that we'd like to have our CSS files be smaller and more compact in production while still giving us the ability to debug in development. The following patch allows you to have an environment specific block like so:

<pre>grass {
    sass_dir = "./src/stylesheets"
    css_dir = "./web-app/css"
    images_dir = "web-app/images"
    relative_assets = true
    framework_output_type = "scss"

    line_comments = false
    output_style = "compressed"
}
environments {
    development {
        grass {
            line_comments = true
            output_style = "compact"
        }
    }
}</pre>
